### PR TITLE
Add prompts to package, to enable 'npm run link'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@foundryvtt/foundryvtt-cli": "^1.0.3",
-        "@types/prompts": "^2.4.9"
+        "@types/prompts": "^2.4.9",
+        "prompts": "^2.4.2"
       }
     },
     "node_modules/@foundryvtt/foundryvtt-cli": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@foundryvtt/foundryvtt-cli": "^1.0.3",
-    "@types/prompts": "^2.4.9"
+    "@types/prompts": "^2.4.9",
+    "prompts": "^2.4.2"
   }
 }


### PR DESCRIPTION
`npm run link` was failing for me locally, probably because the prompts was not installed as part of `npm ci`

I could be wrong though :)